### PR TITLE
Improve data fetching

### DIFF
--- a/data/index.ts
+++ b/data/index.ts
@@ -2,6 +2,7 @@ import WpApiClient, { DefaultEndpoint } from 'wordpress-api-client'
 import {
   FeaturedMedia,
   ModelPostType,
+  PageSlugsByTemplate,
   ProductPostType,
   RepPostType,
   SeriesPostType,
@@ -20,6 +21,8 @@ const PRODUCTS_POST_TYPE_PATH = 'wp/v2/products'
 const REPS_POST_TYPE_PATH = 'wp/v2/reps'
 const SERIES_POST_TYPE_PATH = 'wp/v2/series'
 const STATES_POST_TYPE_PATH = 'wp/v2/states'
+
+const PAGE_SLUGS_PATH = 'puroflux/v1/page-slugs'
 
 class WpClient extends WpApiClient {
   constructor() {
@@ -44,6 +47,7 @@ class WpClient extends WpApiClient {
   footerPagesMenu = this.createEndpointCustomGet<WordPressMenu>(
     FOOTER_PAGES_MENU_PATH
   )
+  pageSlugsByTemplate = this.createEndpointCustomGet<PageSlugsByTemplate>(PAGE_SLUGS_PATH)
 
   public model(): DefaultEndpoint<ModelPostType> {
     return this.addPostType<ModelPostType>(MODELS_POST_TYPE_PATH)

--- a/data/page.ts
+++ b/data/page.ts
@@ -1,14 +1,18 @@
 import { queryBySlug, wpClient } from '.'
 import { ModelPostType, ProductPostType, SeriesPostType } from './types'
 
-export async function getPageData(slug: string) {
+async function getHeroImage(slug: string) {
   const heroImgSlug =
     slug === 'home'
       ? 'puroflux_home_hero_pf_4060'
       : slug.startsWith('pfi')
       ? 'pfi-logo'
       : 'puroflux_home_hero_sample'
-  const [heroImg] = await wpClient.media().find(queryBySlug(heroImgSlug))
+  return await wpClient.media().find(queryBySlug(heroImgSlug))
+}
+
+export async function getUnknownPageData(slug: string) {
+  const [heroImg] = await getHeroImage(slug)
 
   const [page] = await wpClient.page().find(queryBySlug(slug))
   if (!page) {
@@ -147,5 +151,161 @@ export async function getPageData(slug: string) {
       heroImg,
       page
     }
+  }
+}
+
+export async function getProductsTemplateData(slug: string) {
+  const [heroImg] = await getHeroImage(slug)
+
+  const [page] = await wpClient.page().find(queryBySlug(slug))
+  const [addlItem] = await wpClient.page().find(queryBySlug('installations'))
+  const products = await wpClient.product().find()
+
+  return {
+    heroImg,
+    page,
+    addlItem,
+    products
+  }
+}
+
+export async function getStoreLocatorTemplateData(slug: string) {
+  const [heroImg] = await getHeroImage(slug)
+
+  const [page] = await wpClient.page().find(queryBySlug(slug))
+
+  const reps = await wpClient.rep().find()
+  const states = await wpClient.state().find()
+
+  return {
+    heroImg,
+    page,
+    reps,
+    states
+  }
+}
+
+export async function getTypicalInstallationsTemplateData(slug: string) {
+  const [heroImg] = await getHeroImage(slug)
+
+  const [page] = await wpClient.page().find(queryBySlug(slug))
+
+  const series = await wpClient.series().find()
+
+  const filterSeries: SeriesPostType[] = []
+  const separatorSeries: SeriesPostType[] = []
+
+  series.forEach((elt) => {
+    if (!elt) return
+    if (
+      elt.acf.product_series?.find(
+        (p) => p.post_title === 'Permanent Media Filters'
+      )
+    ) {
+      filterSeries.push(elt)
+    } else if (
+      elt.acf.product_series?.find((p) => p.post_title === 'Separators')
+    ) {
+      separatorSeries.push(elt)
+    }
+  })
+
+  return {
+    heroImg,
+    page,
+    filterSeries,
+    separatorSeries
+  }
+}
+
+export async function getPageTemplateData(slug: string) {
+  const [heroImg] = await getHeroImage(slug)
+
+  const [page] = await wpClient.page().find(queryBySlug(slug))
+
+  return {
+    heroImg,
+    page
+  }
+}
+
+export async function getProductTemplateData(slug: string) {
+  const [heroImg] = await getHeroImage(slug)
+
+  const products = await wpClient.product().find(queryBySlug(slug))
+  const product = products.find((p) => p && p.slug === slug)
+
+  // we need more info about the series than what the ACF data provides so we have to fetch :(
+  let series: SeriesPostType[] = []
+  if (product) {
+    const productSeries = product.acf.product_series
+    if (productSeries) {
+      const seriesData = await Promise.all(
+        productSeries.map((node) => wpClient.series().find(node.ID))
+      )
+      seriesData.forEach((node) => {
+        const data = node[0]
+        if (data) series.push(data)
+      })
+    }
+  }
+
+  return {
+    heroImg,
+    page: product,
+    products,
+    series
+  }
+}
+
+export async function getSeriesTemplateData(slug: string) {
+  const [heroImg] = await getHeroImage(slug)
+
+  const products = await wpClient.product().find()
+  const series = await wpClient.series().find()
+  const seriesPage = series.find((p) => p && p.slug === slug)
+  let seriesProduct = {} as ProductPostType
+  let relatedSeries: SeriesPostType[] = []
+  // we need more info about the models than what the ACF data provides so we have to fetch :(
+  let models: ModelPostType[] = []
+  if (seriesPage) {
+    const product = products.find(
+      (p) => p && p.slug === seriesPage.acf.product_series?.[0].post_name
+    )
+    if (product) {
+      seriesProduct = product
+      const productSeries = product.acf.product_series
+      if (productSeries) {
+        productSeries.forEach((node) => {
+          if (node.post_name !== seriesPage.slug) {
+            const related = series.find((p) => p && p.slug === node.post_name)
+            if (related) {
+              relatedSeries.push(related)
+            }
+          }
+        })
+      }
+    }
+
+    const seriesModels = seriesPage.acf.series_models
+    if (seriesModels) {
+      const modelsData = await Promise.all(
+        seriesModels.map((node) => wpClient.model().find(node.ID))
+      )
+      modelsData.forEach((node) => {
+        const data = node[0]
+        if (data) models.push(data)
+      })
+    }
+  }
+
+  return {
+    heroImg,
+    page: seriesPage,
+    models,
+    products,
+    series,
+    seriesProduct,
+    relatedSeries
   }
 }

--- a/data/types.d.ts
+++ b/data/types.d.ts
@@ -226,3 +226,9 @@ export interface ModelPostType extends WordPressPage {
     model_files: null | { title: string; file: WordPressFile }[]
   }
 }
+
+export type PageTypes = 'page' | 'product' | 'series'
+export type PageTemplates = 'page_form.php' | 'page_products.php' | 'page_library.php' | 'page_gallery.php' | 'page_videos.php' | 'page_typical-installations.php' | 'page_contact.php' | 'page_store-locator.php'
+export type PageSlugsByTemplate = {
+  [K in PageTypes | PageTemplates]: string[]
+}

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -4,6 +4,7 @@ import getLayoutData from '../data/layout'
 import {
   getPageTemplateData,
   getProductsTemplateData,
+  getProductTemplateData,
   getSeriesTemplateData,
   getStoreLocatorTemplateData,
   getTypicalInstallationsTemplateData,
@@ -171,7 +172,7 @@ export const getStaticProps: GetStaticProps = async (
       pageData = await getPageTemplateData(slug)
       break
     case 'product':
-      pageData = await getProductsTemplateData(slug)
+      pageData = await getProductTemplateData(slug)
       break
     case 'series':
       pageData = await getSeriesTemplateData(slug)

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,7 +1,14 @@
 import { GetStaticProps, GetStaticPropsContext } from 'next'
 import { wpClient } from '../data'
 import getLayoutData from '../data/layout'
-import { getPageData } from '../data/page'
+import {
+  getPageTemplateData,
+  getProductsTemplateData,
+  getSeriesTemplateData,
+  getStoreLocatorTemplateData,
+  getTypicalInstallationsTemplateData,
+  getUnknownPageData
+} from '../data/page'
 import { HeaderProps } from '../components/header'
 import { FooterProps } from '../components/footer'
 import PageTemplate from '../templates/page'
@@ -17,7 +24,7 @@ import TypicalInstallationsPage, {
   TypicalInstallationsPageProps
 } from '../templates/typical-installations'
 import ProductsPageTemplate, { ProductsPageProps } from '../templates/products'
-import { WordPressPage } from '../data/types'
+import { PageTypes, PageTemplates, WordPressPage } from '../data/types'
 import ProductTemplate, { ProductPageProps } from '../templates/product'
 import SeriesTemplate, { SeriesPageProps } from '../templates/series'
 
@@ -120,13 +127,59 @@ export const getStaticProps: GetStaticProps = async (
   context: GetStaticPropsContext
 ) => {
   const layoutData = await getLayoutData()
+  let pageData = {}
 
-  if (!context.params) return { notFound: true }
-  let slug =
-    (Array.isArray(context.params.slug)
-      ? context.params.slug[0]
-      : context.params.slug) || ''
-  const pageData = await getPageData(slug)
+  if (!context.params?.slug) return { notFound: true }
+  const slug = Array.isArray(context.params.slug)
+    ? context.params.slug[0]
+    : context.params.slug
+
+  // The only info we have about the page is the slug but page templates have different data requirements
+  // This endpoint returns an object where the key is the template and the value is an array of page slugs that use that template
+  const pagesByTemplate = await wpClient.pageSlugsByTemplate()
+
+  if (!pagesByTemplate) {
+    pageData = await getUnknownPageData(slug)
+    return {
+      props: {
+        ...layoutData,
+        ...pageData
+      }
+    }
+  }
+
+  const template = Object.keys(pagesByTemplate).find((template) =>
+    pagesByTemplate[template as PageTypes | PageTemplates].includes(slug)
+  )
+
+  switch (template as PageTypes | PageTemplates) {
+    case 'page_products.php':
+      pageData = await getProductsTemplateData(slug)
+      break
+    case 'page_store-locator.php':
+      pageData = await getStoreLocatorTemplateData(slug)
+      break
+    case 'page_typical-installations.php':
+      pageData = await getTypicalInstallationsTemplateData(slug)
+      break
+    case 'page':
+    case 'page_contact.php':
+    case 'page_form.php':
+    case 'page_gallery.php':
+    case 'page_library.php':
+    case 'page_videos.php':
+      pageData = await getPageTemplateData(slug)
+      break
+    case 'product':
+      pageData = await getProductsTemplateData(slug)
+      break
+    case 'series':
+      pageData = await getSeriesTemplateData(slug)
+      break
+    default:
+      // if the page slug doesn't return a template then it is an invalid slug
+      return { notFound: true }
+  }
 
   return {
     props: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticProps, GetStaticPropsContext } from 'next'
 import getLayoutData from '../data/layout'
 import Layout from '../components/layout'
-import { getPageData } from '../data/page'
+import { getPageTemplateData } from '../data/page'
 import {
   HeroUnit,
   HeroContent,
@@ -104,7 +104,7 @@ export const getStaticProps: GetStaticProps = async (
   context: GetStaticPropsContext
 ) => {
   const layoutData = await getLayoutData()
-  const pageData = await getPageData('home')
+  const pageData = await getPageTemplateData('home')
   return {
     props: {
       ...layoutData,


### PR DESCRIPTION
Inside `getStaticPaths` all we have is the page slug but pages have different data requirements. Previously, we had to make multiple requests until we figured out what kind of page/template was being requested.
A custom API endpoint was added to WP that returns page slugs by template. Inside `getStaticPaths` we'll make a request to this endpoint and then use different functions to fetch the data needed for each template.